### PR TITLE
Add *http.Client into AmazonProductAPI struct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ _______
 
 	import (
 		"fmt"
+		"net/http"
+
 		"github.com/DDRBoxman/go-amazon-product-api"
 	)
 
@@ -24,11 +26,13 @@ _______
 		api.SecretKey = ""
 		api.Host = "webservices.amazon.com"
 		api.AssociateTag = ""
+		api.Client = http.Client // optional
 
-		result,err := api.ItemSearchByKeyword("sgt+frog")
+		result,err := api.ItemSearchByKeyword("sgt+frog", 0)
 		if (err != nil) {
 			fmt.Println(err)
 		}
 
 		fmt.Println(result)
 	}
+

--- a/urlgen.go
+++ b/urlgen.go
@@ -18,6 +18,7 @@ type AmazonProductAPI struct {
 	SecretKey    string
 	AssociateTag string
 	Host         string
+	Client       *http.Client
 }
 
 func (api AmazonProductAPI) genSignAndFetch(Operation string, Parameters map[string]string) (string, error) {
@@ -33,7 +34,11 @@ func (api AmazonProductAPI) genSignAndFetch(Operation string, Parameters map[str
 		return "", err
 	}
 
-	resp, err := http.Get(signedurl)
+	if api.Client == nil {
+		api.Client = http.DefaultClient
+	}
+
+	resp, err := api.Client.Get(signedurl)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Hi, I want to use on Google App Engine.
Please check this Pull request.

sample
```go
.
.

import (
    "github.com/DDRBoxman/go-amazon-product-api"
    "google.golang.org/appengine"
    "google.golang.org/appengine/log"
    "google.golang.org/appengine/urlfetch"
)

.
.
.

    ctx := appengine.NewContext(req)
    var api amazonproduct.AmazonProductAPI

    api.AccessKey = ""
    api.SecretKey = ""
    api.Host = "webservices.amazon.com"
    api.AssociateTag = ""
    api.Client = urlfetch.Client(ctx) // Only set when you want to specify

    result,err := api.ItemSearchByKeyword("sgt+frog", 0)
    if (err != nil) {
        log.Errorf(ctx, err.Error())
    }

    log.Infof(ctx, result)
.
.
.

```
